### PR TITLE
add empty dash style

### DIFF
--- a/manual/manual-2.tex
+++ b/manual/manual-2.tex
@@ -52,7 +52,7 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   remark{Note} = {In most cases, you can omit the underlined key names and write only their values.}
 ]{}
   Key & Description and Values & Initial Value \\
-  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed} or \V{dotted} & \V{solid} \\
+  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed}, \V{dotted} or \V{empty} & \V{solid} \\
   \K{text}             & replace hline with text (like \V{!} specifier in \K{rowspec}) & \None \\
   \underline{\K{wd}}   & rule width dimension & \V{0.4pt} \\
   \underline{\K{fg}}   & rule color name & \None \\
@@ -70,7 +70,7 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   remark{Note} = {In most cases, you can omit the underlined key names and write only their values.}
 ]{}
   Key & Description and Values & Initial Value \\
-  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed} or \V{dotted} & \V{solid} \\
+  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed}, \V{dotted} or \V{empty} & \V{solid} \\
   \K{text}             & replace vline with text (like \V{!} specifier in \K{colspec}) & \None \\
   \underline{\K{wd}}   & rule width dimension & \V{0.4pt} \\
   \underline{\K{fg}}   & rule color name & \None \\

--- a/tabularray.sty
+++ b/tabularray.sty
@@ -1964,6 +1964,7 @@
 
 \NewTblrDashStyle {dashed} {on ~ 2pt ~ off ~ 2pt}
 \NewTblrDashStyle {dotted} {on ~ 0.4pt ~ off ~ 1pt}
+\NewTblrDashStyle {empty} {on ~ 0pt ~ off ~ \maxdimen}
 
 %%% --------------------------------------------------------
 %%> \section{Set hlines and vlines}

--- a/tabularray.tex
+++ b/tabularray.tex
@@ -651,7 +651,7 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   remark{Note} = {In most cases, you can omit the underlined key names and write only their values.}
 ]{}
   Key & Description and Values & Initial Value \\
-  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed} or \V{dotted} & \V{solid} \\
+  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed}, \V{dotted} or \V{empty} & \V{solid} \\
   \K{text}             & replace hline with text (like \V{!} specifier in \K{rowspec}) & \None \\
   \underline{\K{wd}}   & rule width dimension & \V{0.4pt} \\
   \underline{\K{fg}}   & rule color name & \None \\
@@ -669,7 +669,7 @@ All available keys for hlines and vlines are described in Table \ref{key:hline} 
   remark{Note} = {In most cases, you can omit the underlined key names and write only their values.}
 ]{}
   Key & Description and Values & Initial Value \\
-  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed} or \V{dotted} & \V{solid} \\
+  \underline{\K{dash}} & dash style: \V{solid}, \V{dashed}, \V{dotted} or \V{empty} & \V{solid} \\
   \K{text}             & replace vline with text (like \V{!} specifier in \K{colspec}) & \None \\
   \underline{\K{wd}}   & rule width dimension & \V{0.4pt} \\
   \underline{\K{fg}}   & rule color name & \None \\


### PR DESCRIPTION
Instead of drawing many partial lines, it can be sometimes more convenient to first draw all lines and then remove specific segments.

With the existing tools, one can do this by either setting the line width to 0pt (can cause some artifacts in some pdf viewers) or draw the lines in the background colour (problematic with background images etc.)

Personally, I'm usually using a new empty dash style for this, see e.g. https://topanswers.xyz/tex?q=8169#a7767 and thought that might be useful for other users, too.

Here a short test document:

```
\documentclass[border = 3pt]{standalone}

\usepackage{tabularray}

\begin{document}

\begin{tblr}{
  hlines,vlines,
  vline{1} = {1}{empty},
  hline{1} = {1}{empty}
}
  x & x & x\\
  x & x & x\\
  x & x & x\\
\end{tblr}

\end{document}
```

<img width="247" height="231" alt="document-1" src="https://github.com/user-attachments/assets/dba0e9eb-b4e6-435f-9640-423dcf487223" />
